### PR TITLE
Add on-segment mode for pg_dump utility

### DIFF
--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -40,8 +40,8 @@ kwlookup.c: % : $(top_srcdir)/src/backend/parser/%
 
 all: pg_dump pg_restore pg_dumpall
 
-pg_dump: pg_dump.o common.o pg_dump_sort.o $(OBJS) $(KEYWRDOBJS) | submake-libpq submake-libpgport
-	$(CC) $(CFLAGS) pg_dump.o common.o pg_dump_sort.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+pg_dump: pg_dump.o pg_dump_segment_helper.o common.o pg_dump_sort.o $(OBJS) $(KEYWRDOBJS) | submake-libpq submake-libpgport
+	$(CC) $(CFLAGS) pg_dump.o pg_dump_segment_helper.o common.o pg_dump_sort.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 pg_restore: pg_restore.o $(OBJS) $(KEYWRDOBJS) | submake-libpq submake-libpgport
 	$(CC) $(CFLAGS) pg_restore.o $(KEYWRDOBJS) $(OBJS) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
@@ -62,4 +62,4 @@ uninstall:
 
 clean distclean maintainer-clean:
 	$(MAKE) -C test clean
-	rm -f pg_dump$(X) pg_restore$(X) pg_dumpall$(X) $(OBJS) pg_dump.o common.o pg_dump_sort.o pg_restore.o pg_dumpall.o kwlookup.c $(KEYWRDOBJS)
+	rm -f pg_dump$(X) pg_restore$(X) pg_dumpall$(X) $(OBJS) pg_dump.o common.o pg_dump_sort.o pg_restore.o pg_dumpall.o pg_dump_segment_helper.o kwlookup.c $(KEYWRDOBJS)

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -356,7 +356,8 @@ RestoreArchive(Archive *AHX)
 	if (ropt->filename || ropt->compression)
 		SetOutput(AH, ropt->filename, ropt->compression);
 
-	ahprintf(AH, "--\n-- Greenplum Database database dump\n--\n\n");
+	if (!AH->dataOnly)
+		ahprintf(AH, "--\n-- Greenplum Database database dump\n--\n\n");
 
 	if (AH->public.verbose)
 	{
@@ -380,7 +381,8 @@ RestoreArchive(Archive *AHX)
 	/*
 	 * Establish important parameter values right away.
 	 */
-	_doSetFixedOutputState(AH);
+	if(!AH->dataOnly)
+		_doSetFixedOutputState(AH);
 
 	AH->stage = STAGE_PROCESSING;
 
@@ -634,7 +636,8 @@ RestoreArchive(Archive *AHX)
 	if (AH->public.verbose)
 		dumpTimestamp(AH, "Completed on", time(NULL));
 
-	ahprintf(AH, "--\n-- Greenplum Database database dump complete\n--\n\n");
+	if (!AH->dataOnly)
+		ahprintf(AH, "--\n-- Greenplum Database database dump complete\n--\n\n");
 
 	/*
 	 * Clean up & we're done.
@@ -2350,6 +2353,8 @@ _allocAH(const char *FileSpec, const ArchiveFormat fmt,
 		default:
 			exit_horribly(modulename, "unrecognized file format \"%d\"\n", fmt);
 	}
+
+	AH->dataOnly = 0;
 
 	return AH;
 }

--- a/src/bin/pg_dump/pg_backup_archiver.h
+++ b/src/bin/pg_dump/pg_backup_archiver.h
@@ -323,6 +323,7 @@ typedef struct _archiveHandle
 								 * required */
 	ArchiverOutput outputKind;	/* Flag for what we're currently writing */
 	bool		pgCopyIn;		/* Currently in libpq 'COPY IN' mode. */
+	int			dataOnly;		/* Flag for using Archive only for raw data */
 
 	int			loFd;			/* BLOB fd */
 	int			writingBlob;	/* Flag */

--- a/src/bin/pg_dump/pg_backup_tar.c
+++ b/src/bin/pg_dump/pg_backup_tar.c
@@ -796,6 +796,15 @@ _PrintTocData(ArchiveHandle *AH, TocEntry *te, RestoreOptions *ropt)
 	{
 		if (te->copyStmt)
 		{
+			/*
+			 * GPDB: Check if we're dumping on segment
+			 * If so just keep return without editing COPY command
+			 */
+			pos1 = (int) strlen(te->copyStmt);
+			if (pos1 >= 6 + 13 /* " ON SEGMENT;\n" */ &&
+				strcmp(te->copyStmt + pos1 - 13, " ON SEGMENT;\n") == 0)
+				return;
+
 			/* Abort the COPY FROM stdin */
 			ahprintf(AH, "\\.\n");
 

--- a/src/bin/pg_dump/pg_dump_segment_helper.c
+++ b/src/bin/pg_dump/pg_dump_segment_helper.c
@@ -1,0 +1,219 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_dump_segment_helper.c
+ *	  pg_dump_segment_helper provides functions which saves data from stdin
+ *	  to files and restores data from files to stdout
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "parallel.h"
+
+#include <ctype.h>
+
+#include "pg_backup.h"
+#include "pg_backup_archiver.h"
+#include "pg_backup_utils.h"
+#include "pg_dump_segment_helper.h"
+
+static int runRestore_Archive(const char *inputFileSpec);
+static int runRestore_PlainText(const char *inputFileSpec);
+#ifdef HAVE_LIBZ
+static int runRestore_CompressedPlainText(const char *inputFileSpec);
+#endif
+
+static void setupDumpWorkerDummy(Archive *AH, RestoreOptions *ropt);
+
+static void addDumpableObject(Archive *AH);
+static void ConfigureForClearData(Archive *AH);
+static int	getDumpFromStdin(Archive *AH, void *dcontext);
+
+int
+onSegmentHelper_RunDump(const char *inputFileSpec, int compressLevel, ArchiveFormat format)
+{
+	Archive		   *AH;
+	RestoreOptions *ropt;
+
+	int plainText = 0;
+
+	/* archiveFormat specific setup */
+	if (format == archNull)
+		plainText = 1;
+
+	/* Open the output file */
+	AH = CreateArchive(
+		inputFileSpec, format, compressLevel, archModeWrite, setupDumpWorkerDummy
+	);
+
+	/* Register the cleanup hook */
+	on_exit_close_archive(AH);
+
+	if (AH == NULL)
+		exit_horribly(NULL, "could not open output file \"%s\" for writing\n", inputFileSpec);
+
+	ConfigureForClearData(AH);
+
+	addDumpableObject(AH);
+
+	/*
+	 * Set up options info to ensure we dump what we want.
+	 */
+	ropt = NewRestoreOptions();
+	ropt->filename = inputFileSpec;
+
+	if (compressLevel == -1)
+		ropt->compression = 0;
+	else
+		ropt->compression = compressLevel;
+
+	((ArchiveHandle *)AH)->ropt = ropt;
+
+	if (plainText)
+		RestoreArchive(AH);
+
+	CloseArchive(AH);
+
+	return 0;
+}
+
+int
+onSegmentHelper_RunRestore(const char *inputFileSpec, int compressLevel, ArchiveFormat format)
+{
+	if (format != archNull)
+		return runRestore_Archive(inputFileSpec);
+#ifdef HAVE_LIBZ
+	if (compressLevel != 0)
+		return runRestore_CompressedPlainText(inputFileSpec);
+#endif
+	else
+		return runRestore_PlainText(inputFileSpec);
+}
+
+static int
+runRestore_Archive(const char *inputFileSpec)
+{
+	RestoreOptions *opts;
+	Archive		   *AH;
+	int				exitCode = 0;
+
+	AH = OpenArchive(inputFileSpec, archUnknown);
+
+	on_exit_close_archive(AH);
+
+	ConfigureForClearData(AH);
+
+	opts = NewRestoreOptions();
+
+	SetArchiveRestoreOptions(AH, opts);
+	RestoreArchive(AH);
+
+	if (AH->n_errors)
+		fprintf(stderr, _("WARNING: errors ignored on restore: %d\n"), AH->n_errors);
+
+	exitCode = AH->n_errors ? 1 : 0;
+
+	CloseArchive(AH);
+
+	return exitCode;
+}
+
+static int
+runRestore_PlainText(const char *inputFileSpec)
+{
+	int	  exitCode = 0;
+	FILE *readFd = fopen(inputFileSpec, "r");
+	if (!readFd)
+	{
+		fprintf(stderr, _("Couldn't open plain text file for reading\n"));
+		return 1;
+	}
+
+	const int	bufferSize = 1024;
+	const char *buffer[bufferSize];
+
+	size_t readLen = 0;
+	while ((readLen = fread(buffer, sizeof(char), bufferSize, readFd)) > 0)
+	{
+		if (fwrite(buffer, readLen, sizeof(char), stdout) == 0)
+		{
+			fprintf(stderr, _("Error while writing to stdout\n"));
+			exitCode = 1;
+			break;
+		}
+	}
+
+	fclose(readFd);
+
+	return exitCode;
+}
+
+#ifdef HAVE_LIBZ
+static int
+runRestore_CompressedPlainText(const char *inputFileSpec)
+{
+	int	   exitCode = 0;
+	gzFile readFd = gzopen(inputFileSpec, "rb");
+	if (!readFd)
+	{
+		fprintf(stderr, _("Couldn't open .gz file for reading\n"));
+		return 1;
+	}
+
+	const int	bufferSize = 8192;
+	const char *buffer[bufferSize];
+
+	size_t readLen = 0;
+	while ((readLen = GZREAD(buffer, sizeof(char), bufferSize, readFd)) > 0)
+	{
+		if (fwrite(buffer, readLen, sizeof(char), stdout) == 0)
+		{
+			fprintf(stderr, _("Error while writing to stdout\n"));
+			exitCode = 1;
+			break;
+		}
+	}
+
+	GZCLOSE(readFd);
+
+	return exitCode;
+}
+#endif
+
+static void
+addDumpableObject(Archive *AH)
+{
+	DumpableObject dobj = {.name = "", .dumpId = 1};
+	ArchiveHandle *AHH = (ArchiveHandle *)AH;
+
+	ArchiveEntry(
+		AH, dobj.catId, dobj.dumpId, dobj.name, NULL, NULL, "", false, "", SECTION_DATA, "", "",
+		NULL, NULL, 0, getDumpFromStdin, NULL
+	);
+
+	AHH->toc->next->reqs = REQ_DATA;
+}
+
+/* We dont want any comments or SET operators in segments' dumps */
+static void
+ConfigureForClearData(Archive *AH)
+{
+	ArchiveHandle *AHH = (ArchiveHandle *)AH;
+
+	AHH->noTocComments = 1;
+	AHH->dataOnly = 1;
+}
+
+static int
+getDumpFromStdin(Archive *AH, void *dcontext)
+{
+	char copybuf[1000];
+	while (fgets(copybuf, sizeof copybuf, stdin) != NULL)
+		WriteData(AH, copybuf, strlen(copybuf));
+
+	return 1;
+}
+
+static void
+setupDumpWorkerDummy(Archive *AH, RestoreOptions *ropt)
+{
+}

--- a/src/bin/pg_dump/pg_dump_segment_helper.h
+++ b/src/bin/pg_dump/pg_dump_segment_helper.h
@@ -16,3 +16,4 @@ extern int onSegmentHelper_RunRestore(const char *inputFileSpec, int compressLev
 extern int onSegmentHelper_RunDump(const char *inputFileSpec, int compressLevel, ArchiveFormat format);
 
 #endif // PG_DUMP_SEGMENT_HELPER
+

--- a/src/bin/pg_dump/pg_dump_segment_helper.h
+++ b/src/bin/pg_dump/pg_dump_segment_helper.h
@@ -1,0 +1,18 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_dump_segment_helper.h
+ *	  pg_dump_segment_helper provides public interface for saving data
+ *	  from stdin and restoring data to stdout
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PG_DUMP_SEGMENT_HELPER
+#define PG_DUMP_SEGMENT_HELPER
+
+#include "pg_backup.h"
+
+extern int onSegmentHelper_RunRestore(const char *inputFileSpec, int compressLevel, ArchiveFormat format);
+extern int onSegmentHelper_RunDump(const char *inputFileSpec, int compressLevel, ArchiveFormat format);
+
+#endif // PG_DUMP_SEGMENT_HELPER


### PR DESCRIPTION
Add pg_dump on-segment mode, where data is stored locally on segments

This mode gets activated by using --on-segment flag, it generates dump on client side as usual and data dumps on each used segment, compression level and archive formats are forwarded to segments' archives
Generated dump can be used by pg_restore or psql (for plain texts) as usual

Also to manage data on segments 2 other system modes were added. 
First one (--on-segment-internal-dump-mode) reads data from stdin to stores it locally with forwarded archive format and compression level.
Second (--on-segment-internal-restore-mode) reads stored data and passes it to stdout

In this mode utility uses COPY ... TO PROGRAM ... ON SEGMENT instead of normal COPY and passes output of it to pg_dump on each segment.
To restore data it saves COPY ... FROM PROGRAM ... ON SEGMENT operators to final dump, which read data from utility on each segment. 